### PR TITLE
fix: Add missing 'Product Info' field to admin product edit form

### DIFF
--- a/src/component/Admin/UpdateProduct.jsx
+++ b/src/component/Admin/UpdateProduct.jsx
@@ -169,6 +169,20 @@ function UpdateProduct() {
                       onChange={(e) => setStock(e.target.value)}
                     />
                   </div>
+
+                  <div>
+                    <label htmlFor="productInfo" className="block text-gray-700 mb-2">Product Info</label>
+                    <input
+                      type="text"
+                      id="productInfo"
+                      className="w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                      placeholder="Product Info"
+                      value={info}
+                      onChange={(e) => setInfo(e.target.value)}
+                      required
+                    />
+                  </div>
+
                   <div>
                     <label className="block text-gray-700 mb-2">Size</label>
                     <input


### PR DESCRIPTION
The 'Product Info' field was missing from the user interface when editing a product in the admin dashboard, although it was present when adding a new product. This commit rectifies this omission.

Changes made:
- Added an input field for 'Product Info' (field name `info`) to the JSX form in `src/component/Admin/UpdateProduct.jsx`.
- This input field is bound to the existing `info` state variable in the component.
- The field is marked as `required` for consistency with the 'New Product' form.
- Ensured the label and styling match other form fields.

The existing logic for fetching `product.info` into the component's state and for including the `info` field in the `FormData` payload during product updates was already in place and required no changes. This fix purely addresses the missing UI element.